### PR TITLE
Support for Subset data type

### DIFF
--- a/torchsampler/imbalanced.py
+++ b/torchsampler/imbalanced.py
@@ -45,6 +45,8 @@ class ImbalancedDatasetSampler(torch.utils.data.sampler.Sampler):
             return dataset.train_labels[idx].item()
         elif isinstance(dataset, torchvision.datasets.ImageFolder):
             return dataset.imgs[idx][1]
+        elif isinstance(dataset, torch.utils.data.Subset):
+            return dataset.dataset.imgs[idx][1]
         elif self.callback_get_label:
             return self.callback_get_label(dataset, idx)
         else:


### PR DESCRIPTION
Imbalanced sampling for pytorch Subsets. This is helpful when we create KFold splits on torchvision.datasets.ImageFolder data types