### PR TITLE
Adds support for DatasetFolder

### DIFF
--- a/torchsampler/imbalanced.py
+++ b/torchsampler/imbalanced.py
@@ -41,6 +41,8 @@ class ImbalancedDatasetSampler(torch.utils.data.sampler.Sampler):
             return dataset.train_labels[idx].item()
         elif isinstance(dataset, torchvision.datasets.ImageFolder):
             return dataset.imgs[idx][1]
+        elif isinstance(dataset, torchvision.datasets.DatasetFolder):
+            return dataset.samples[idx][1]
         elif isinstance(dataset, torch.utils.data.Subset):
             return dataset.dataset.imgs[idx][1]
         else:


### PR DESCRIPTION
As per its source code, it uses `samples` instead of `imgs`:

https://pytorch.org/vision/stable/_modules/torchvision/datasets/folder.html#DatasetFolder