### PR TITLE
reduce the time when calling sampler

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 torch>=1.3
 torchvision>=0.5
+pandas

--- a/torchsampler/imbalanced.py
+++ b/torchsampler/imbalanced.py
@@ -1,5 +1,6 @@
 from typing import Callable
 
+import pandas as pd
 import torch
 import torch.utils.data
 import torchvision
@@ -25,28 +26,30 @@ class ImbalancedDatasetSampler(torch.utils.data.sampler.Sampler):
         self.num_samples = len(self.indices) if num_samples is None else num_samples
 
         # distribution of classes in the dataset
-        label_to_count = {}
-        for idx in self.indices:
-            label = self._get_label(dataset, idx)
-            label_to_count[label] = label_to_count.get(label, 0) + 1
+        df = pd.DataFrame()
+        df["label"] = self._get_labels(dataset)
+        df.index = self.indices
+        df = df.sort_index()
 
-        # weight for each sample
-        weights = [1.0 / label_to_count[self._get_label(dataset, idx)] for idx in self.indices]
+        label_to_count = df["label"].value_counts()
+
+        weights = 1.0 / label_to_count(df["label"])
+
         self.weights = torch.DoubleTensor(weights)
 
-    def _get_label(self, dataset, idx):
+    def _get_labels(self, dataset):
         if self.callback_get_label:
-            return self.callback_get_label(dataset, idx)
+            return self.callback_get_label(dataset)
         elif isinstance(dataset, torchvision.datasets.MNIST):
-            return dataset.train_labels[idx].item()
+            return dataset.train_labels.tolist()
         elif isinstance(dataset, torchvision.datasets.ImageFolder):
-            return dataset.imgs[idx][1]
+            return dataset.imgs[:][1]
         elif isinstance(dataset, torchvision.datasets.DatasetFolder):
-            return dataset.samples[idx][1]
+            return dataset.samples[:][1]
         elif isinstance(dataset, torch.utils.data.Subset):
-            return dataset.dataset.imgs[idx][1]
+            return dataset.dataset.imgs[:][1]
         elif isinstance(dataset, torch.utils.data.Dataset):
-            return dataset.get_label(idx)
+            return dataset.get_labels()
         else:
             raise NotImplementedError
 


### PR DESCRIPTION
In the current code, it has lots of costs for calculating weights and statistics of the number of each label when calling init().
It might be a problem when incoming a large dataset, so I changed this part using pandas.
I checked it reduces time within 1 second when I use over 5 million data. (In previous code, it takes 20 minutes to use a sampler)