### PR TITLE
add labels param to ImbalancedDatasetSampler

### DIFF
--- a/torchsampler/imbalanced.py
+++ b/torchsampler/imbalanced.py
@@ -15,7 +15,14 @@ class ImbalancedDatasetSampler(torch.utils.data.sampler.Sampler):
         callback_get_label: a callback-like function which takes two arguments - dataset and index
     """
 
-    def __init__(self, dataset, indices: list = None, num_samples: int = None, callback_get_label: Callable = None):
+    def __init__(
+        self,
+        dataset,
+        labels: list = None,
+        indices: list = None,
+        num_samples: int = None,
+        callback_get_label: Callable = None,
+    ):
         # if indices is not provided, all elements in the dataset will be considered
         self.indices = list(range(len(dataset))) if indices is None else indices
 
@@ -27,7 +34,7 @@ class ImbalancedDatasetSampler(torch.utils.data.sampler.Sampler):
 
         # distribution of classes in the dataset
         df = pd.DataFrame()
-        df["label"] = self._get_labels(dataset)
+        df["label"] = self._get_labels(dataset) if labels is None else labels
         df.index = self.indices
         df = df.sort_index()
 
@@ -54,7 +61,10 @@ class ImbalancedDatasetSampler(torch.utils.data.sampler.Sampler):
             raise NotImplementedError
 
     def __iter__(self):
-        return (self.indices[i] for i in torch.multinomial(self.weights, self.num_samples, replacement=True))
+        return (
+            self.indices[i]
+            for i in torch.multinomial(self.weights, self.num_samples, replacement=True)
+        )
 
     def __len__(self):
         return self.num_samples

--- a/torchsampler/imbalanced.py
+++ b/torchsampler/imbalanced.py
@@ -61,10 +61,7 @@ class ImbalancedDatasetSampler(torch.utils.data.sampler.Sampler):
             raise NotImplementedError
 
     def __iter__(self):
-        return (
-            self.indices[i]
-            for i in torch.multinomial(self.weights, self.num_samples, replacement=True)
-        )
+        return (self.indices[i] for i in torch.multinomial(self.weights, self.num_samples, replacement=True))
 
     def __len__(self):
         return self.num_samples


### PR DESCRIPTION
Add labels to the parameter list to allow for labels to be passed directly in the situation of using a custom Dataset with no ._get_labels() method. 