### PR TITLE
Publish package to PyPi and GitHub Releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+# ref: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Publish Package
+
+on:
+  # publish from the Releases page:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Publish Package
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: actions/setup-python@v3
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+
+    - name: Build
+      run: python -m build
+
+    - name: Publish to Github
+      uses: softprops/action-gh-release@v1
+      with:
+        files: 'dist/*'
+        fail_on_unmatched_files: true
+        prerelease: ${{ contains(github.ref, 'rc') || contains(github.ref, 'dev') }}
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ In this repo, we implement an easy-to-use PyTorch sampler `ImbalancedDatasetSamp
 ## Usage
 
 For a simple start install the package via one of following ways:
+
 ```bash
-pip install https://github.com/ufoym/imbalanced-dataset-sampler/archive/master.zip
+pip install torchsampler
 ```
 
 


### PR DESCRIPTION
Here at https://github.com/neuropoly/ we think your project is very useful and would like to build on it! Unfortunately if we write a setup.cfg for ourselves that depends on "torchsampler", it fails to install, because https://pypi.org/project/torchsampler/ is a 404:

![Screenshot 2022-04-29 at 14-51-02 Page Not Found (404)](https://user-images.githubusercontent.com/987487/166007997-3536c032-6b18-444f-8897-24c0b36e7ffa.png)

This Workflow script makes publishing the conventional way easy and reliable, and will mean that projects like ours can build on your work!

To use it,

1. Create an account at https://pypi.org/
2. Go to https://pypi.org/manage/account/token/ and make a token
3. Go to  then go to https://github.com/kousu/imbalanced-dataset-sampler/settings/secrets/actions and paste the token in there, with name "PYPI_TOKEN"

Then every time you are ready to publish, 

1. Go to https://github.com/ufoym/imbalanced-dataset-sampler/releases/new,
2. Fill in a new tag like "1.0.0"
3. Click Publish.

It will run the Action and then in a minute or so will show up on https://github.com/kousu/imbalanced-dataset-sampler/releases/ and https://pypi.org/project/torchsampler/#history

For your first few runs, while you get used to this script, I recommend using ["rc" suffixes](https://peps.python.org/pep-0440/#pre-releases) to post versions without committing to them. For example, I've [used this script myself](https://pypi.org/project/radicale-bsdauth/#history) to produce

![Screenshot 2022-04-29 at 15-04-19 radicale-bsdauth](https://user-images.githubusercontent.com/987487/166009791-64135fe5-c3bf-4af2-b21e-d21d30642b2a.png)

the ones with the yellow "pre-release" tags get ignored by `pip` by default, unless a user opts into them with `pip install --pre`.

Publishing to PyPI will avoid issues like

* https://github.com/ufoym/imbalanced-dataset-sampler/issues/20
* https://github.com/ufoym/imbalanced-dataset-sampler/issues/15
* https://github.com/ufoym/imbalanced-dataset-sampler/issues/12

and again, let us build on your work. Without publishing to pypi, it means our install instructions need to include yours:

```
pip install https://github.com/ufoym/imbalanced-dataset-sampler/archive/master.zip neuropoly-seg-model
```

which is pretty awkward for us.

Thanks a lot for your work, it's really helping out our research prototyping.