### PR TITLE
Use setuptools_scm

### DIFF
--- a/.github/workflows/ci_install-pkg.yml
+++ b/.github/workflows/ci_install-pkg.yml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Check package
         run: |
-          pip install check-manifest
-          check-manifest
           python setup.py check --metadata --strict
 
       - name: Create package

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,18 +1,7 @@
-# Manifest syntax https://docs.python.org/2/distutils/sourcedist.html
-graft wheelhouse
+# Manifest syntax https://setuptools.pypa.io/en/latest/deprecated/distutils/commandref.html#sdist-cmd
 
-recursive-exclude __pycache__  *.py[cod] *.orig
-
-# Include the README
-include *.md
-
-# Include the license file
-include LICENSE
-
-recursive-include torchsampler *.py
-
-# Include the Requirements
-include requirements.txt
+# FIXME: switching to a src/ layout would obviate the need for this file entirely.
+#        see https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#src-layout
 
 # Exclude build configs
 exclude *.yml
@@ -20,5 +9,3 @@ exclude *.yaml
 
 prune .github
 prune example*
-prune temp*
-prune test*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 torch>=1.3
 torchvision>=0.5
 pandas
+importlib_metadata; python_version<'3.8'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 torch>=1.3
 torchvision>=0.5
 pandas
+# only needed by __about__.py, which is deprecated:
 importlib_metadata; python_version<'3.8'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 license_file = LICENSE
-description-file = README.md
 
 [flake8]
 max-line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ long_description = (PATH_HERE / 'README.md').read_text()
 
 setup(
     name='torchsampler',
-    version=about.__version__,
+    use_scm_version=True,
     url=about.__homepage__,
     author=about.__author__,
     author_email=about.__author_email__,
@@ -30,6 +30,7 @@ setup(
     long_description_content_type='text/markdown',
     packages=['torchsampler'],
     keywords='sampler,pytorch,dataloader',
+    setup_requires=['setuptools_scm'],
     install_requires=requirements,
     python_requires='>=3.6',
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,8 @@
 """A setuptools based setup module."""
 
-import sys
 from pathlib import Path
 
 from setuptools import setup
-
-try:
-    from torchsampler import __about__ as about
-except ImportError:
-    # alternative https://stackoverflow.com/a/67692/4521646
-    sys.path.append("torchsampler")
-    import __about__ as about
 
 PATH_HERE = Path(__file__).parent
 
@@ -21,11 +13,12 @@ long_description = (PATH_HERE / 'README.md').read_text()
 setup(
     name='torchsampler',
     use_scm_version=True,
-    url=about.__homepage__,
-    author=about.__author__,
-    author_email=about.__author_email__,
-    license=about.__license__,
-    description=about.__doc__,
+    url="https://github.com/ufoym/imbalanced-dataset-sample",
+    author="Ming, et al.",
+    author_email="a@ufoym.com",
+    license="MIT",
+    description="A (PyTorch) imbalanced dataset sampler for oversampling low classes"
+    "and undersampling high frequent ones.",
     long_description=long_description,
     long_description_content_type='text/markdown',
     packages=['torchsampler'],

--- a/torchsampler/__about__.py
+++ b/torchsampler/__about__.py
@@ -1,3 +1,15 @@
+import sys
+
+if sys.version_info < (3, 8):
+    from importlib_metadata import PackageNotFoundError, version
+else:
+    from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("torchsampler")
+except PackageNotFoundError:
+    # package is not installed (i.e. we're probably in the build process itself)
+    pass
 __version__ = "0.1.1"
 __author__ = "Ming, et al."
 __author_email__ = "a@ufoym.com"

--- a/torchsampler/__about__.py
+++ b/torchsampler/__about__.py
@@ -1,22 +1,31 @@
 import sys
 
 if sys.version_info < (3, 8):
-    from importlib_metadata import PackageNotFoundError, version
+    from importlib_metadata import distribution, PackageNotFoundError
 else:
-    from importlib.metadata import PackageNotFoundError, version
+    from importlib.metadata import distribution, PackageNotFoundError
+
+import warnings
+
+warnings.warn(
+    "Use importlib.metadata.distribution('torchsampler').metadata instead of torchsampler.__about__.",
+    category=DeprecationWarning
+)
 
 try:
-    __version__ = version("torchsampler")
+    _m = distribution('torchsampler').metadata
+    __version__ = _m['version']
+    __author__ = _m['author']
+    __author_email__ = _m['author-email']
+    __license__ = _m['license']
+    __homepage__ = _m['homepage']
+    __doc__ = _m['summary']
+    del _m
 except PackageNotFoundError:
     # package is not installed (i.e. we're probably in the build process itself)
     pass
-__version__ = "0.1.1"
-__author__ = "Ming, et al."
-__author_email__ = "a@ufoym.com"
-__license__ = "MIT"
-__homepage__ = "https://github.com/ufoym/imbalanced-dataset-sampler"
-__doc__ = "A (PyTorch) imbalanced dataset sampler for oversampling low frequent classes" \
-          " and undersampling high frequent ones."
+
+del sys, distribution, PackageNotFoundError, warnings
 
 __all__ = [
     "__author__",


### PR DESCRIPTION
Follows up https://github.com/ufoym/imbalanced-dataset-sampler/pull/47

- on [pypi](https://pypi.org/project/torchsampler/0.1.1/) it's 0.1.1
- on github it's [0.1.0](https://github.com/ufoym/imbalanced-dataset-sampler/releases/tag/v0.1.0)
    - but the attached [wheel](https://github.com/ufoym/imbalanced-dataset-sampler/releases/download/v0.1.0/torchsampler-0.1.1-py3-none-any.whl) and [sdist](https://github.com/ufoym/imbalanced-dataset-sampler/releases/download/v0.1.0/torchsampler-0.1.1.tar.gz) are 0.1.1

[`setuptools-scm`](https://pypi.org/project/setuptools-scm/) makes git the single-source of truth for the version of the package, and works well with the build script in #47 (which is triggered by tagging a new version in git).

The other thing `setuptools-scm` does is make git the single source of truth for your `MANIFEST`, so this drops `check-manifest` and also most of the contents of your `MANIFEST.in` -- except the prune lines, those are still doing something for the moment.